### PR TITLE
Fixes wrong sampling rate. This matches the schematics

### DIFF
--- a/Konami/007232/HDL/k007232.v
+++ b/Konami/007232/HDL/k007232.v
@@ -73,7 +73,7 @@ module k007232(
 	end
 
 	wire CLKd1024 = CLKDIV[7];
-	wire CLKd4 = D69;
+	wire CLKd4 = F74; // buffer G57
 
 	// Output data latches
 	always @(negedge CLKd4)


### PR DESCRIPTION
This is a typo in the RTL code. The schematics were correct. Without fixing this, the sampling rate is halved and thus everything sounds too low.