### PR TITLE
pan-off bit and gain of auxiliary input

### DIFF
--- a/Konami/054539/README.md
+++ b/Konami/054539/README.md
@@ -220,6 +220,14 @@ There are two look-up tables in ROMB starting at address 192. Each 4-bit pan val
 
 The panning value is a 16-bit width and goes into multiplier B.
 
+Bit 1 of the control register $22F can be set in order to disable panning and have the same gain for both channels.
+
+# Auxiliary Input
+
+The auxiliary input is used to mix the sound from an external source. It can take either a stereo 16-bit signal, or decode Yamaha's mantissa/exponent format. The pin **YMD** selects the data format. The volume for the auxiliary input is set by one of registers $228,$229,$22A and $22B. Which register is used is set by bits 1:0 of registers $210 (left) and $211 (right).
+
+*To do* confirm that it is not $210 (right) and $211 (left) instead.
+
 # Registers
 
 Some infos from MAME.
@@ -287,7 +295,7 @@ fTIM = CLK / 256 / (255 - REG227)
 * 22E: Bits [7:0] used, bit 7 selects ROM/RAM, bits [6:0] are top address bits for CPU access (POST), bits [16:0] come from an internal up-counter clocked by accesses to register 22D.
 * 22F: General control (Enable, timer, ...)
   * Bit 0: Active-low mute for all digital outputs
-  * Bit 1: ?
+  * Bit 1: Disables panning
   * Bit 4: Low: reset internal address counter for ROM/RAM test
   * Bit 5: Low: disable TIM output (keep high), force timer counter load with value from 227
   * Bit 7: Disable internal RAM internal updates


### PR DESCRIPTION
Identified a few more register meanings. Please see the diff for details.

Registers $210 and $211 were checked with _Run and Gun_ and _X-Men_, which use the auxiliary input. These two registers gave good results, where as the other two candidates $212 and $213 did not work well, particularly for _Run and Gun_. 

I also ran some simulations trying to identify the inputs of MULB to the auxiliary signal and the right volume. But it was pointing me to $212 and $213. As I said, these two don't work well in real games. There might have been something wrong in my setup or in the schematics. I am not sure yet. But $210 and $211 do work well in the two tested games.